### PR TITLE
fix bug in get_groups_with_perms function

### DIFF
--- a/guardian/shortcuts.py
+++ b/guardian/shortcuts.py
@@ -382,7 +382,7 @@ def get_groups_with_perms(obj, attach_perms=False):
         group_perms_mapping = defaultdict(list)
         groups_with_perms = get_groups_with_perms(obj)
         qs = group_model.objects.filter(group__in=groups_with_perms).prefetch_related('group', 'permission')
-        if group_model is GroupObjectPermission:
+        if group_model.objects.is_generic():
             qs = qs.filter(object_pk=obj.pk, content_type=ctype)
         else:
             qs = qs.filter(content_object_id=obj.pk)


### PR DESCRIPTION
In get_groups_with_perms, we are currently checking if the group_model is GroupObjectPermission.

With the changes in add-group-mixin, which allows custom group_models, this causes a potential error.

Switching to the check  group_model.objects.is_generic() is more accurate. this is also used in other places in the shortcuts to have the same result.

Therefore i refactored all is GroupObjectPermission checks to objects.is_generic() checks.